### PR TITLE
Upgraded to 1.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.hmsonline</groupId>
 			<artifactId>hms-cassandra-mapreduce</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>hms-cassandra-rest</artifactId>
@@ -53,23 +54,20 @@
 			<version>1.9.3</version>
 		</dependency>
 		<dependency>
-			<groupId>com.hmsonline</groupId>
-			<artifactId>hms-cassandra-triggers</artifactId>
-			<version>1.0.0</version>
-			<exclusions>
-				<exclusion>
-					<artifactId>guava</artifactId>
-					<groupId>com.google.guava</groupId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.jackson</groupId>
-					<artifactId>jackson-mapper-asl</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.jackson</groupId>
-					<artifactId>jackson-core-asl</artifactId>
-				</exclusion>
-			</exclusions>
+			<groupId>org.jboss.netty</groupId>
+			<artifactId>netty</artifactId>
+			<version>3.2.9.Final</version>
+		</dependency>
+		<!-- Disabling triggers for now. -->
+		<!-- <dependency> <groupId>com.hmsonline</groupId> <artifactId>hms-cassandra-triggers</artifactId> 
+			<version>1.0.0</version> <exclusions> <exclusion> <artifactId>guava</artifactId> 
+			<groupId>com.google.guava</groupId> </exclusion> <exclusion> <groupId>org.codehaus.jackson</groupId> 
+			<artifactId>jackson-mapper-asl</artifactId> </exclusion> <exclusion> <groupId>org.codehaus.jackson</groupId> 
+			<artifactId>jackson-core-asl</artifactId> </exclusion> </exclusions> </dependency> -->
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>aspectjrt</artifactId>
+			<version>1.6.11</version>
 		</dependency>
 		<dependency>
 			<groupId>com.yammer.dropwizard</groupId>

--- a/src/main/java/com/hmsonline/virgil/CassandraStorage.java
+++ b/src/main/java/com/hmsonline/virgil/CassandraStorage.java
@@ -79,9 +79,9 @@ public class CassandraStorage extends ConnectionPoolClient {
         ConnectionPool.initializePool();
         if (VirgilConfiguration.isEmbedded()) {
             // Force instantiation of the singletons
-            ConfigurationStore.getStore().create();
-            TriggerStore.getStore().create();
-            CommitLog.getCommitLog().create();
+            //ConfigurationStore.getStore().create();
+            //TriggerStore.getStore().create();
+            //CommitLog.getCommitLog().create();
         }
     }
 

--- a/src/main/java/com/hmsonline/virgil/cli/VirgilCommand.java
+++ b/src/main/java/com/hmsonline/virgil/cli/VirgilCommand.java
@@ -1,6 +1,6 @@
 package com.hmsonline.virgil.cli;
 
-import org.apache.cassandra.thrift.CassandraDaemon;
+import org.apache.cassandra.service.CassandraDaemon;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionBuilder;

--- a/src/test/resources/cassandra_test.yaml
+++ b/src/test/resources/cassandra_test.yaml
@@ -26,8 +26,6 @@ hinted_handoff_enabled: true
 # this defines the maximum amount of time a dead host will have hints
 # generated.  After it has been dead this long, hints will be dropped.
 max_hint_window_in_ms: 3600000 # one hour
-# Sleep this long after delivering each row or row fragment
-hinted_handoff_throttle_delay_in_ms: 50
 
 # authentication backend, implementing IAuthenticator; used to identify users
 authenticator: org.apache.cassandra.auth.AllowAllAuthenticator
@@ -303,9 +301,6 @@ compaction_preheat_key_cache: true
 # can lead to saturating the network connection and degrading rpc performance.
 # When unset, the default is 400 Mbps or 50 MB/s.
 # stream_throughput_outbound_megabits_per_sec: 400
-
-# Time to wait for a reply from other nodes before failing the command 
-rpc_timeout_in_ms: 10000
 
 # phi value that must be reached for a host to be marked down.
 # most users should never need to adjust this.


### PR DESCRIPTION
Moved to SNAPSHOT dependency of mapreduce to get the upgrade on Cassandra and the snappy-java upgrade.

Fixed the configuration file for test_cassandra to remove params that are no longer pertinent.
